### PR TITLE
Upgrade to work with modern kamon-core

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -13,19 +13,18 @@
  * =========================================================================================
  */
 
-val kamonCore       = "io.kamon"        %% "kamon-core"                     % "1.0.0-RC1"
-val kamonTestkit    = "io.kamon"        %% "kamon-testkit"                  % "1.0.0-RC1"
+val kamonCore       = "io.kamon"        %% "kamon-core"                     % "1.1.0"
+val kamonTestkit    = "io.kamon"        %% "kamon-testkit"                  % "1.1.0"
 
 val netty           = "io.netty"        %  "netty-all"                      % "4.0.51.Final"
 val nettyNative     = "io.netty"        %  "netty-transport-native-epoll"   % "4.0.51.Final"    classifier "linux-x86_64"
 val logback         = "ch.qos.logback"  %  "logback-classic"                % "1.0.13"
 
-
 lazy val root = (project in file("."))
   .settings(Seq(
       name := "kamon-netty",
-      scalaVersion := "2.12.3",
-      crossScalaVersions := Seq("2.11.8", "2.12.3")))
+      scalaVersion := "2.12.7",
+      crossScalaVersions := Seq("2.11.12", "2.12.7")))
   .enablePlugins(JavaAgent)
   .settings(isSnapshot := true)
   .settings(resolvers += Resolver.bintrayRepo("kamon-io", "snapshots"))

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.13
+sbt.version=0.13.16

--- a/src/main/scala/kamon/netty/Metrics.scala
+++ b/src/main/scala/kamon/netty/Metrics.scala
@@ -31,9 +31,9 @@ object Metrics {
     *    - task-queue-size: The number of tasks that are pending for processing.
     *    - task-waiting-time: The waiting time in the queue.
     */
-  val registeredChannelsMetric = Kamon.minMaxCounter("netty.event-loop.registered-channels")
+  val registeredChannelsMetric = Kamon.rangeSampler("netty.event-loop.registered-channels")
   val taskProcessingTimeMetric = Kamon.histogram("netty.event-loop.task-processing-time", time.nanoseconds)
-  val taskQueueSizeMetric = Kamon.minMaxCounter("netty.event-loop.task-queue-size")
+  val taskQueueSizeMetric = Kamon.rangeSampler("netty.event-loop.task-queue-size")
   val taskWaitingTimeMetric = Kamon.histogram("netty.event-loop.task-waiting-time", time.nanoseconds)
 
 
@@ -49,9 +49,9 @@ object Metrics {
   }
 
   case class EventLoopMetrics(tags: Map[String, String],
-                              registeredChannels: MinMaxCounter,
+                              registeredChannels: RangeSampler,
                               taskProcessingTime: Histogram,
-                              taskQueueSize: MinMaxCounter,
+                              taskQueueSize: RangeSampler,
                               taskWaitingTime: Histogram) {
 
     def cleanup(): Unit = {

--- a/src/main/scala/kamon/netty/instrumentation/HttpClientInstrumentation.scala
+++ b/src/main/scala/kamon/netty/instrumentation/HttpClientInstrumentation.scala
@@ -68,7 +68,7 @@ class HttpClientInstrumentation {
 
   @AfterThrowing("decoderPointcut() && args(ctx, *, *)")
   def onDecodeError(ctx: ChannelHandlerContext): Unit = {
-    val clientSpan = ctx.channel().getContext().get(Span.ContextKey)
-    clientSpan.addTag("error", value = true).finish()
+    val clientSpan: Span = ctx.channel().getContext().get(Span.ContextKey)
+    clientSpan.tag("error", value = true).finish()
   }
 }

--- a/src/main/scala/kamon/netty/instrumentation/HttpServerInstrumentation.scala
+++ b/src/main/scala/kamon/netty/instrumentation/HttpServerInstrumentation.scala
@@ -16,12 +16,14 @@
 
 package kamon.netty.instrumentation
 
+import java.time.Instant
+
 import io.netty.channel.ChannelHandlerContext
 import io.netty.handler.codec.http.HttpResponse
 import kamon.Kamon
 import kamon.netty.Netty
 import kamon.trace.Span
-import org.aspectj.lang.annotation.{After, Aspect, Before}
+import org.aspectj.lang.annotation.{ After, Aspect, Before }
 
 @Aspect
 class HttpServerInstrumentation {
@@ -34,7 +36,7 @@ class HttpServerInstrumentation {
       val incomingContext = decodeContext(request)
       val serverSpan = Kamon.buildSpan(Netty.generateOperationName(request))
         .asChildOf(incomingContext.get(Span.ContextKey))
-        .withStartTimestamp(channel.startTime)
+        .withFrom(Instant.ofEpochMilli(channel.startTime))
         .withTag("span.kind", "server")
         .withTag("component", "netty")
         .withTag("http.method", request.getMethod.name())

--- a/src/main/scala/kamon/netty/instrumentation/HttpServerInstrumentation.scala
+++ b/src/main/scala/kamon/netty/instrumentation/HttpServerInstrumentation.scala
@@ -49,7 +49,7 @@ class HttpServerInstrumentation {
   def onEncodeResponse(ctx: ChannelHandlerContext, response:HttpResponse): Unit = {
     val serverSpan = ctx.channel().getContext().get(Span.ContextKey)
     if(isError(response.getStatus.code()))
-      serverSpan.addTag("error", value = true)
+      serverSpan.tag("error", value = true)
     serverSpan.finish()
   }
 }

--- a/src/main/scala/kamon/netty/instrumentation/NioEventLoopInstrumentation.scala
+++ b/src/main/scala/kamon/netty/instrumentation/NioEventLoopInstrumentation.scala
@@ -19,8 +19,8 @@ package kamon.netty.instrumentation
 import java.util
 
 import io.netty.channel.nio.NioEventLoop
-import io.netty.channel.{ChannelFuture, ChannelFutureListener}
-import kamon.metric.MinMaxCounter
+import io.netty.channel.{ ChannelFuture, ChannelFutureListener }
+import kamon.metric.RangeSampler
 import kamon.netty.Metrics
 import kamon.netty.util.EventLoopUtils._
 import kamon.netty.util.MonitoredQueue
@@ -46,7 +46,7 @@ class NioEventLoopInstrumentation {
     registeredChannels.decrement()
   }
 
-  val registeredChannelListener: MinMaxCounter  => ChannelFutureListener = registeredChannels => new ChannelFutureListener() {
+  val registeredChannelListener: RangeSampler  => ChannelFutureListener = registeredChannels => new ChannelFutureListener() {
     override def operationComplete(future: ChannelFuture): Unit = {
       if(future.isSuccess) {
         registeredChannels.increment()

--- a/src/main/scala/kamon/netty/instrumentation/ServerBootstrapInstrumentation.scala
+++ b/src/main/scala/kamon/netty/instrumentation/ServerBootstrapInstrumentation.scala
@@ -16,7 +16,8 @@
 
 package kamon.netty.instrumentation
 
-import io.netty.channel.{Channel, ChannelHandler, ChannelHandlerContext, ChannelInboundHandlerAdapter}
+import io.netty.channel.{ Channel, ChannelHandler, ChannelHandlerContext, ChannelInboundHandlerAdapter }
+import kamon.Kamon
 import kamon.util.Clock
 import org.aspectj.lang.annotation._
 
@@ -52,7 +53,7 @@ object ServerBootstrapInstrumentation {
   @ChannelHandler.Sharable
   private class KamonHandler extends ChannelInboundHandlerAdapter {
     override def channelRead(ctx: ChannelHandlerContext, msg: AnyRef): Unit = {
-      ctx.channel().toContextAware().startTime = Clock.microTimestamp()
+      ctx.channel().toContextAware().startTime = Clock.toEpochMicros(Kamon.clock().instant())
       super.channelRead(ctx, msg)
     }
   }

--- a/src/main/scala/kamon/netty/util/Latency.scala
+++ b/src/main/scala/kamon/netty/util/Latency.scala
@@ -16,15 +16,15 @@
 
 package kamon.netty.util
 
+import kamon.Kamon
 import kamon.metric.Histogram
-import kamon.util.Clock
-
 
 object Latency {
   def measure[A](histogram: Histogram)(thunk: ⇒ A): A = {
-    val start = Clock.relativeNanoTimestamp()
+    val clock = Kamon.clock()
+    val start = clock.nanos()
     try thunk finally {
-      val latency = Clock.relativeNanoTimestamp() - start
+      val latency = clock.nanos() - start
       histogram.record(latency)
     }
   }

--- a/src/main/scala/kamon/netty/util/MonitoredQueue.scala
+++ b/src/main/scala/kamon/netty/util/MonitoredQueue.scala
@@ -64,13 +64,13 @@ object MonitoredQueue {
   def apply(eventLoop: EventLoop, underlying: util.Queue[Runnable]): MonitoredQueue =
     new MonitoredQueue(eventLoop, underlying)
 
-  def timeInQueue(runnable: Runnable):Long =
+  def timeInQueue(runnable: Runnable): Long =
     runnable.asInstanceOf[TimedTask].timeInQueue
-
 }
 
 private[this] class TimedTask(underlying:Runnable)(implicit metrics: EventLoopMetrics) extends Runnable with HasContext {
-  val startTime:Long =  Clock.relativeNanoTimestamp()
+  val clock: Clock = Kamon.clock()
+  val startTime: Long =  clock.nanos()
   val context: Context = Kamon.currentContext()
 
   override def run(): Unit =
@@ -79,5 +79,5 @@ private[this] class TimedTask(underlying:Runnable)(implicit metrics: EventLoopMe
     }
 
   def timeInQueue: Long =
-    Clock.relativeNanoTimestamp() - startTime
+    clock.nanos() - startTime
 }

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.0.0-RC1-SNAPSHOT"
+version in ThisBuild := "1.0.1-RC1-SNAPSHOT"


### PR DESCRIPTION
- Replaced `MinMaxCounter`s with `RangeSampler`s
- Use the new clock instance instead of `Clock.microTimestamp()`